### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ make status
       "command": "docker",
       "args": [
         "exec", "-i", 
-        "synapse-mcp-server-1", 
+        "synapse-main-mcp-server-1", 
         "python", "/app/server_fastmcp.py"
       ],
       "env": {}


### PR DESCRIPTION
Fixed a small typo in MCP setup example. (I couldn't get LM studio to connect with `synapse-mcp-server-1`, but `synapse-main-mcp-server-1` seems to be correct.)